### PR TITLE
Log stage directory errors with do/catch

### DIFF
--- a/iOS/ContentView.swift
+++ b/iOS/ContentView.swift
@@ -83,6 +83,14 @@ struct ContentView: View {
                 shareItems = []
             }) { ShareSheet(activityItems: shareItems) }
             .onDisappear { peer.stopBrowsing() }
+            .alert("Stage Error", isPresented: Binding<Bool>(
+                get: { stage.lastError != nil },
+                set: { _ in stage.lastError = nil }
+            )) {
+                Button("OK", role: .cancel) { stage.lastError = nil }
+            } message: {
+                Text(stage.lastError ?? "")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace `try?` calls with `do`/`catch` blocks when creating or removing the stage directory
- surface stage directory failures through a published `lastError` property
- display an alert in the UI when a stage error occurs

## Testing
- `swiftc iOS/StageManager.swift -emit-objc-header-path /tmp/StageManager.h` *(fails: cannot find type 'ObservableObject' in scope)*
- `swiftc iOS/ContentView.swift -emit-objc-header-path /tmp/ContentView.h` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689871517bec832e93965b62270fe88d