### PR TITLE
Clean up temp directories after reconstruction

### DIFF
--- a/macOS/ContentView.swift
+++ b/macOS/ContentView.swift
@@ -52,12 +52,13 @@ struct ContentView: View {
         }
         .padding()
         .frame(minWidth: 820, minHeight: 480)
-        .onDisappear { cleanupFilteredFolder() }
+        .onDisappear { cleanupFilteredFolder(); peer.cleanupRootDirectory() }
         .onReceive(peer.$receivedFolder) { folder in
             if let folder {
                 let filtered = filterToImages(folder)
                 stagedFolder = filtered
                 status = "Received files: \(countImages(in: filtered))"
+                peer.cleanupRootDirectory()
             }
         }
     }
@@ -108,6 +109,7 @@ struct ContentView: View {
             status = "Cancelled"
         } catch { status = "Failed: \(error.localizedDescription)" }
         reconSession = nil
+        peer.cleanupRootDirectory()
     }
 
     func askForSaveURL(format: ModelFormat) -> URL? {

--- a/macOS/ReceiverPeer.swift
+++ b/macOS/ReceiverPeer.swift
@@ -10,6 +10,7 @@ final class ReceiverPeer: NSObject, ObservableObject {
 
     @Published var connectionStatus = "Not connected"
     @Published var receivedFolder: URL?
+    private var rootTempDirectory: URL?
 
     override init() {
         super.init()
@@ -21,6 +22,16 @@ final class ReceiverPeer: NSObject, ObservableObject {
 
     func startAdvertising() { advertiser.startAdvertisingPeer(); connectionStatus = "Advertising…" }
     func stopAdvertising() { advertiser.stopAdvertisingPeer(); connectionStatus = "Not advertising" }
+
+    func cleanupRootDirectory() {
+        guard let root = rootTempDirectory else { return }
+        rootTempDirectory = nil
+        Task.detached(priority: .background) {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    deinit { cleanupRootDirectory() }
 }
 
 extension ReceiverPeer: MCNearbyServiceAdvertiserDelegate, MCSessionDelegate {
@@ -77,6 +88,7 @@ extension ReceiverPeer: MCNearbyServiceAdvertiserDelegate, MCSessionDelegate {
 
             await MainActor.run {
                 self?.receivedFolder = expanded
+                self?.rootTempDirectory = root
                 self?.connectionStatus = "Received \(resourceName)"
             }
         }


### PR DESCRIPTION
## Summary
- track root temp dir for received zips
- asynchronously delete temp dir after staging, reconstruction, or app exit

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_6898712f74c8832e94d9da128ace83d6