### PR TITLE
Fix compile errors in CapturePeer and SimpleZip

### DIFF
--- a/iOS/CapturePreview/CapturePreview/CapturePeer.swift
+++ b/iOS/CapturePreview/CapturePreview/CapturePeer.swift
@@ -26,7 +26,7 @@ final class CapturePeer: NSObject, ObservableObject {
     func sendFile(_ url: URL) async throws {
         guard let dest = session.connectedPeers.first else { throw NSError(domain: "NoPeers", code: 1) }
         let name = url.lastPathComponent
-        try await withCheckedThrowingContinuation { cont in
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             let progress = session.sendResource(at: url, withName: name, toPeer: dest) { [weak self] error in
                 Task { @MainActor in
                     if let error {

--- a/iOS/CapturePreview/CapturePreview/SimpleZip.swift
+++ b/iOS/CapturePreview/CapturePreview/SimpleZip.swift
@@ -94,10 +94,15 @@ enum SimpleZip {
 
     private static func write(_ bytes: [UInt8], to out: OutputStream) throws -> Int {
         var idx = 0, total = 0
-        while idx < bytes.count {
-            let n = out.write(bytes[idx...], maxLength: bytes.count - idx)
-            if n <= 0 { throw ZipError(message: "Output stream write failed") }
-            idx += n; total += n
+        try bytes.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                throw ZipError(message: "Output stream write failed")
+            }
+            while idx < bytes.count {
+                let n = out.write(base.advanced(by: idx), maxLength: bytes.count - idx)
+                if n <= 0 { throw ZipError(message: "Output stream write failed") }
+                idx += n; total += n
+            }
         }
         return total
     }


### PR DESCRIPTION
## Summary
- clarify continuation type in `CapturePeer.sendFile`
- convert array slice to pointer in `SimpleZip.write`

## Testing
- `swiftc -typecheck iOS/CapturePreview/CapturePreview/SimpleZip.swift`
- `swiftc -typecheck iOS/CapturePreview/CapturePreview/CapturePeer.swift` *(fails: no such module 'MultipeerConnectivity')*

------
https://chatgpt.com/codex/tasks/task_e_689877e5c9fc832e9910c57c767db77f