### PR TITLE
Fix ObjectCapture session integration

### DIFF
--- a/iOS/CapturePreview/CapturePreview/GuidedCaptureView.swift
+++ b/iOS/CapturePreview/CapturePreview/GuidedCaptureView.swift
@@ -79,9 +79,9 @@ struct ObjectCaptureContainer: UIViewControllerRepresentable {
     }
 }
 
-final class ObjectCaptureViewController: UIViewController, ObjectCaptureSessionDelegate {
-    private var captureView: ObjectCaptureView<ObjectCaptureViewController>!
-    private var session: ObjectCaptureSession!
+final class ObjectCaptureViewController: UIViewController, RealityKit.ObjectCaptureSessionDelegate {
+    private var captureView: ObjectCaptureView<EmptyView>!
+    private var session: RealityKit.ObjectCaptureSession!
 
     // Provided by SwiftUI
     var stageURL: URL = FileManager.default.temporaryDirectory
@@ -101,7 +101,7 @@ final class ObjectCaptureViewController: UIViewController, ObjectCaptureSessionD
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        session = ObjectCaptureSession()
+        session = RealityKit.ObjectCaptureSession()
         session.delegate = self
         session.sampleBufferCaptureEnabled = true
         session.isObjectMaskingEnabled = true
@@ -132,7 +132,7 @@ final class ObjectCaptureViewController: UIViewController, ObjectCaptureSessionD
     }
 
     // MARK: - ObjectCaptureSessionDelegate
-    func objectCaptureSession(_ session: ObjectCaptureSession, didAdd sample: ObjectCaptureSession.Sample) {
+    func objectCaptureSession(_ session: RealityKit.ObjectCaptureSession, didAdd sample: RealityKit.ObjectCaptureSession.Sample) {
         if isPaused { return }
         if turntableMode {
             let now = CACurrentMediaTime()
@@ -149,7 +149,7 @@ final class ObjectCaptureViewController: UIViewController, ObjectCaptureSessionD
         }
     }
 
-    func objectCaptureSession(_ session: ObjectCaptureSession, didChange state: ObjectCaptureSession.CaptureState) {
+    func objectCaptureSession(_ session: RealityKit.ObjectCaptureSession, didChange state: RealityKit.ObjectCaptureSession.CaptureState) {
         DispatchQueue.main.async { [weak self] in
             switch state {
             case .initializing: self?.hudLabel.text = "Initializing…"


### PR DESCRIPTION
## Summary
- use `RealityKit.ObjectCaptureSession` to access delegate-based API
- instantiate `ObjectCaptureView` without a controller overlay

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68987b73138c832e83cc99169f388813